### PR TITLE
Spawn With Wheelchair Quirk

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -160,3 +160,20 @@
 	value = 0
 	category = CATEGORY_SEXUAL
 	medical_record_text = "Patient's legs seem to lack strength"
+
+/datum/quirk/SpawnWithWheelchair
+	name = "Mobility Assistance"
+	desc = "After your last failed fitness test, you were advised to start using a wheelchair"
+	category = CATEGORY_MOVEMENT
+/datum/quirk/SpawnWithWheelchair/on_spawn()
+	if(quirk_holder.buckled) // Handle late joins being buckled to arrival shuttle chairs.
+		quirk_holder.buckled.unbuckle_mob(quirk_holder)
+
+	var/turf/T = get_turf(quirk_holder)
+	var/obj/structure/chair/spawn_chair = locate() in T
+
+	var/obj/vehicle/ridden/wheelchair/wheels = new(T)
+	if(spawn_chair) // Makes spawning on the arrivals shuttle more consistent looking
+		wheels.setDir(spawn_chair.dir)
+
+	wheels.buckle_mob(quirk_holder)


### PR DESCRIPTION
Allows a player to select a quirk that spawns them with a wheelchair.

At least one person has directly requested this quirk and I beleve a few other people may be interested in using it.
The quirk is neutral and costs 0 points, it can be found under movement quirks, called Mobility Assistance.

on_spawn() code coppied from the parapalegic quirk.