### PR TITLE
Fat cyborgs.

### DIFF
--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -313,7 +313,8 @@
 				"BootyF" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootymedical"),
 				"BootyM" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootymedicalM"),
 				"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootymedicalS"),
-				"Haydee" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "haydeemedical")
+				"Haydee" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "haydeemedical"),
+				"Fat" = image(icon = 'GainStation13/icons/mob/robots.dmi', icon_state = "fat_medical")
 		)
 		med_models = sortList(med_models)
 	var/medi_borg_icon = show_radial_menu(R, R , med_models, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE, tooltips = TRUE)
@@ -353,6 +354,10 @@
 		if("Haydee")
 			cyborg_base_icon = "haydeemedical"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
+			hat_offset = 3
+		if("Fat")
+			cyborg_base_icon = "fat_medical"
+			cyborg_icon_override = 'GainStation13/icons/mob/robots.dmi'
 			hat_offset = 3
 	return ..()
 
@@ -412,7 +417,8 @@
 			"Spider" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "whitespider"),
 			"BootyF" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootypeace"),
 			"BootyM" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootypeaceM"),
-			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootypeaceS")
+			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootypeaceS"),
+			"Fat" = image(icon = 'GainStation13/icons/mob/robots.dmi', icon_state = "fat_peacekeeper")
 		)
 		peace_models = sortList(peace_models)
 	var/peace_borg_icon = show_radial_menu(R, R , peace_models, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE, tooltips = TRUE)
@@ -436,6 +442,10 @@
 			cyborg_base_icon = "bootypeaceS"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
 			hat_offset = 3
+		if("Fat")
+			cyborg_base_icon = "fat_peacekeeper"
+			cyborg_icon_override = 'GainStation13/icons/mob/robots.dmi'
+			hat_offset = 3
 	return ..()
 
 /obj/item/robot_module/security/be_transformed_to(obj/item/robot_module/old_module)
@@ -452,7 +462,8 @@
 			"Heavy" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "heavysec"),
 			"BootyF" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootysecurity"),
 			"BootyM" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootysecurityM"),
-			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootysecurityS")
+			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootysecurityS"),
+			"Fat" = image(icon = 'GainStation13/icons/mob/robots.dmi', icon_state = "fat_security")
 		)
 		sec_models = sortList(sec_models)
 	var/sec_borg_icon = show_radial_menu(R, R , sec_models, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE, tooltips = TRUE)
@@ -492,6 +503,10 @@
 			cyborg_base_icon = "bootysecurityS"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
 			hat_offset = 3
+		if("Fat")
+			cyborg_base_icon = "fat_security"
+			cyborg_icon_override = 'GainStation13/icons/mob/robots.dmi'
+			hat_offset = 3
 	return ..()
 
 /obj/item/robot_module/butler/be_transformed_to(obj/item/robot_module/old_module)
@@ -508,7 +523,8 @@
 			"Heavy" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "heavyserv"),
 			"BootyF" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyservice"),
 			"BootyM" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyserviceM"),
-			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyserviceS")
+			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyserviceS"),
+			"Fat" = image(icon = 'GainStation13/icons/mob/robots.dmi', icon_state = "fat_service")
 		)
 		butler_models = sortList(butler_models)
 	var/butler_borg_icon = show_radial_menu(R, R , butler_models, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE, tooltips = TRUE)
@@ -549,6 +565,10 @@
 			cyborg_base_icon = "bootyserviceS"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
 			hat_offset = 3
+		if("Fat")
+			cyborg_base_icon = "fat_service"
+			cyborg_icon_override = 'GainStation13/icons/mob/robots.dmi'
+			hat_offset = 3
 	return ..()
 
 /obj/item/robot_module/engineering/be_transformed_to(obj/item/robot_module/old_module)
@@ -567,7 +587,8 @@
 			"Heavy" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "heavyeng"),
 			"BootyF" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyengineer"),
 			"BootyM" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyengineerM"),
-			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyengineerS")
+			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyengineerS"),
+			"Fat" = image(icon = 'GainStation13/icons/mob/robots.dmi', icon_state = "fat_engineer")
 		)
 		/*var/list/L = list("Pupdozer" = "pupdozer", "Engihound" = "Engihound")
 		for(var/a in L)
@@ -648,6 +669,10 @@
 			cyborg_base_icon = "bootyengineerS"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
 			hat_offset = 3
+		if("Fat")
+			cyborg_base_icon = "fat_engineer"
+			cyborg_icon_override = 'GainStation13/icons/mob/robots.dmi'
+			hat_offset = 3
 	return ..()
 
 /obj/item/robot_module/miner/be_transformed_to(obj/item/robot_module/old_module)
@@ -665,7 +690,8 @@
 			"Heavy" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "heavymin"),
 			"BootyF" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyminer"),
 			"BootyM" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyminerM"),
-			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyminerS")
+			"BootyS" = image(icon = 'modular_citadel/icons/mob/robots.dmi', icon_state = "bootyminerS"),
+			"Fat" = image(icon = 'GainStation13/icons/mob/robots.dmi', icon_state = "fat_mining")
 		)
 		miner_models = sortList(miner_models)
 	var/miner_borg_icon = show_radial_menu(R, R , miner_models, custom_check = CALLBACK(src, .proc/check_menu, R), radius = 42, require_near = TRUE, tooltips = TRUE)
@@ -707,6 +733,10 @@
 		if("BootyS")
 			cyborg_base_icon = "bootyminerS"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
+			hat_offset = 3
+		if("Fat")
+			cyborg_base_icon = "fat_mining"
+			cyborg_icon_override = 'GainStation13/icons/mob/robots.dmi'
 			hat_offset = 3
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the "Fat" cyborg modules to the list of available cyborg appearances for the following cyborg types: Engineering, Mining, Security, Medical, Service and Peacekeeper. They appear on the selection wheel correctly and are correctly applied to cyborgs.
![image](https://user-images.githubusercontent.com/109332231/183081982-d80b6713-ba32-438a-8d0d-c4387e326ecd.png)
![image](https://user-images.githubusercontent.com/109332231/183082687-8d9814c7-ca43-466e-81c4-e8104402ed1d.png)
![image](https://user-images.githubusercontent.com/109332231/183082805-0f7d02b5-2217-48f8-ab4e-7a60d775436a.png)
![image](https://user-images.githubusercontent.com/109332231/183082907-3901eabc-0f3a-47f2-9225-04bd5ca87ec4.png)
![image](https://user-images.githubusercontent.com/109332231/183083013-10aa94a0-10f5-455f-9149-68feebcc32cc.png)

Sprites themselves NOT MADE BY ME, they were already provided in the game files, made by Agent Legit 22#8403 on Discord.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fat cyborgs. What is not to love?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added fat cyborgs.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
