### PR TITLE
Spelling error and code comment

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2476,9 +2476,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 //GS13 fatness
 
 				if("fatness")
-					var/new_fatness = input(user, "Choose your amount of fat at start :\n(0-2000), Fat changes appearance and move speed. \nThresholds are 90, 150, 350, 500 and 900. Warning : If using the 'weak legs' trait, bieng too fat will make you immobile and unable to leave the shuttle without a wheelchair or help", "Character Preference") as num|null
+					var/new_fatness = input(user, "Choose your amount of fat at start :\n(0-4000), Fat changes appearance and move speed. \nThresholds are 200, 440, 1240, 1840 and 3400. Warning : If using the 'weak legs' trait, being too fat will make you immobile and unable to leave the shuttle without a wheelchair or help", "Character Preference") as num|null
 					if (new_fatness)
-						starting_weight = max(min( round(text2num(new_fatness)), 2000),0)
+						starting_weight = max(min( round(text2num(new_fatness)), 4000),0)
 
 				if("ui")
 					var/pickedui = input(user, "Choose your UI style.", "Character Preference", UI_style)  as null|anything in GLOB.available_ui_styles

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1332,6 +1332,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 
 	if (H.nutrition > NUTRITION_LEVEL_FULL)
+		// fatConversionRate is functionally useless. It seems under normal curcumstances, each tick only processes, at most, 1 nutrition anyway. reducing the value has no effect.
 		var/fatConversionRate = 100 //GS13 what percentage of the excess nutrition should go to fat (total nutrition to transfer can't be under 1)
 		var/nutritionThatBecomesFat = max((H.nutrition - NUTRITION_LEVEL_FULL)*(fatConversionRate / 100),1)
 		H.nutrition -= nutritionThatBecomesFat


### PR DESCRIPTION
Fixed a spelling error in the start fatness input window.
Commented the fatness conversion code to point out a coding oversight.