### PR TITLE
Virus tweaks

### DIFF
--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -70,7 +70,7 @@
 										/datum/reagent/medicine/haloperidol, /datum/reagent/drug/aranesp, /datum/reagent/medicine/diphenhydramine
 									),
 									list(	//level 11
-										/datum/reagent/medicine/modafinil, /datum/reagent/medicine/bicaridine
+										/datum/reagent/medicine/modafinil, /datum/reagent/drug/krokodil
 									)
 								)
 
@@ -243,7 +243,14 @@
 		else
 			visibility_flags &= ~HIDDEN_SCANNER
 
-		SetSpread(CLAMP(2 ** (properties["transmittable"] - symptoms.len), DISEASE_SPREAD_BLOOD, DISEASE_SPREAD_AIRBORNE))
+		if(properties["transmittable"]>=11)
+			SetSpread(DISEASE_SPREAD_AIRBORNE)
+		else if(properties["transmittable"]>=7)
+			SetSpread(DISEASE_SPREAD_CONTACT_SKIN)
+		else if(properties["transmittable"]>=3)
+			SetSpread(DISEASE_SPREAD_CONTACT_FLUIDS)
+		else
+			SetSpread(DISEASE_SPREAD_BLOOD)
 
 		permeability_mod = max(CEILING(0.4 * properties["transmittable"], 1), 1)
 		cure_chance = 15 - CLAMP(properties["resistance"], -5, 5) // can be between 10 and 20
@@ -419,7 +426,7 @@
 
 	 // Should be only 1 entry left, but if not let's only return a single entry
 	var/datum/disease/advance/to_return = pick(diseases)
-	to_return.Refresh(1)
+	to_return.Refresh(TRUE)
 	return to_return
 
 /proc/SetViruses(datum/reagent/R, list/data)
@@ -455,7 +462,8 @@
 			else if(ispath(symptom))
 				var/datum/symptom/S = new symptom
 				if(!D.HasSymptom(S))
-					D.symptoms += S
+					D.symptoms += S //We manually add to avoid the randomness
+					S.OnAdd(D) //Second step of adding a symptom
 					i -= 1
 	while(i > 0)
 

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -36,7 +36,8 @@
 		var/datum/symptom/chosen_symptom = pick_n_take(possible_symptoms)
 		if(chosen_symptom)
 			var/datum/symptom/S = new chosen_symptom
-			symptoms += S
+			symptoms += S //Avoiding the randomness
+			S.OnAdd(src) //Activating symptoms added
 
 	name = "Sample #[rand(1,10000)]"
 	..()

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -22,7 +22,7 @@
 
 /datum/round_event/disease_outbreak/start()
 	var/advanced_virus = FALSE
-	max_severity = 3 + max(FLOOR((world.time - control.earliest_start)/6000, 1),0) //3 symptoms at 20 minutes, plus 1 per 10 minutes
+	max_severity = 3 + CLAMP(FLOOR((world.time - control.earliest_start)/6000, 1),0, 5) //3 symptoms at 20 minutes, plus 1 per 10 minutes, maximum 8 to prevent it getting all symptoms
 	if(prob(20 + (10 * max_severity)))
 		advanced_virus = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Tweaks a few virus things, most notably the requirements for transmission types. Other changes include :
- one of the max resistance cure changed form bicaridine (come on) to krokodil.
- fixing the admin virus creation to notably properly change infectable biotypes (races).
- limiting the event that gave too many symptoms to 8 max. 
- I have also decided to add a symptom that specifically allows the infection of robotic races. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
- Transmission: The old transmission was very limiting on discrete viruses. Stealth symptoms are terrible at transmission and it was virtually impossible to counterbalance with the old system. Now you at least have a shot at fluid trnasmission. Still bad, but you can make smoke or splash it.
- Max resistance cure: Bicaridine? Really? Going through the trouble of giving your virus 13 resistance (for 6 symptoms) only for it to be cured with something chemists probably have on a macro is very disappointing. There were already a few drugs on there so it should be fine. This one is maybe a bit deadlier on addiction. We'll just have to trust the medical staff.
- Admin virus: This one is straight forward. Before your virus could not infect the things its symptoms allowed it to.
- The event was sad. The main cause were our really long rounds really. With a new symptom every 10 minutes the event was capping out very often. The total stats were always terrible and it was honestly probably a bit mean anyways if it ever came to stage 5. Maybe now it can roll something actually dangerous. Maybe not. But it will at least change between happenings.
- The new symptom will allow robotic races to get in on virus fun, since people will chose player race for its appearance rather than mechanics most of the times, this should help those player access virology content. It has average stats, but does have stealth and non-abysmal transmission. It is still much worse than revitiligo, while having an actual effect. Not too hard to change if someone breaks it.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: New Symptom to infect robotic races
tweak: Changed requirements for transmission types
tweak: Disease breakout event caps out at 8 symptoms
balance: Resistance level 13 does not include bicaridine as a possible cure
fix: Admin virus creation with race symptoms
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
