### PR TITLE
Nerfs the respawn timer down to 3 minutes

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -288,7 +288,7 @@
 
 	observer.started_as_observer = TRUE
 	src.client.respawn_observing = 1
-	src.client.lastrespawn = world.time + 1800 SECONDS //reset respawn.
+	src.client.lastrespawn = world.time + 180 SECONDS //reset respawn.
 	close_spawn_windows()
 	var/obj/effect/landmark/observer_start/O = locate(/obj/effect/landmark/observer_start) in GLOB.landmarks_list
 	to_chat(src, "<span class='notice'>Now teleporting.</span>")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -289,7 +289,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(istype(loc, /obj/machinery/cryopod))
 		var/response = alert(src, "Are you -sure- you want to ghost?\n(If you ghost now, you will have to wait 30 minutes before you are able to respawn!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")//darn copypaste
-			client.lastrespawn = world.time + 1800 SECONDS //set respawn time
+			client.lastrespawn = world.time + 180 SECONDS //set respawn time
 			return
 		var/obj/machinery/cryopod/C = loc
 		C.despawn_occupant()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -471,7 +471,7 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
 		qdel(M)
 		return
 
-	usr.client.lastrespawn = world.time + 1800 SECONDS
+	usr.client.lastrespawn = world.time + 180 SECONDS
 	usr.client.respawn_observing = 0
 	message_admins("[client.ckey] respawned.")
 	M.ckey = ckey //shamelessly copied to


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Changes the respawn timer added by all forms of ghosting besides death to be 3 minutes instead of 30 minutes. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
People can easily circumvent this anyways, so lowering the time on it doesn't seem like a bad change.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
config: changed respawn timers for non-death to be 3 minutes instead of 30
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
