### PR TITLE
Fatal vore now adds weight from digesting the prey

### DIFF
--- a/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
@@ -107,6 +107,17 @@
 				M.visible_message("<span class='notice'>You watch as [owner]'s form loses its additions.</span>")
 
 				owner.nutrition += 400 // so eating dead mobs gives you *something*.
+				//GS13 EDIT
+				
+				var/mob/living/carbon/gainer = owner
+				if(iscarbon(gainer) && owner?.client?.prefs?.weight_gain_food)	
+					var/mob/living/carbon/prey = M
+					if(iscarbon(prey) && prey.fatness)
+						var/fatness_to_add = (prey.fatness * 0.75)
+						gainer.adjust_fatness(fatness_to_add, FATTENING_TYPE_FOOD)
+				
+				//GS13 EDIT END
+
 				if((world.time - NORMIE_HEARCHECK) > last_hearcheck)
 					LAZYCLEARLIST(hearing_mobs)
 					for(var/mob/living/H in get_hearers_in_view(3, source))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
When digesting a prey with fatness, assuming that the weight gain from food pref is enabled, the pred will gain 80% of the fatness from the prey.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It makes sense for vore to have integrations with our fat system
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Fatal vore now has weight gain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
