### PR TITLE
hair iconpath fix

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories/hair_head.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories/hair_head.dm
@@ -379,7 +379,7 @@
 
 /datum/sprite_accessory/hair/gloomylong
 	name = "Gloomy (Long)"
-	icon_state = "hair_gloomy"
+	icon_state = "hair_gloomylong"
 
 /datum/sprite_accessory/hair/glossy
 	name = "Glossy"
@@ -535,7 +535,7 @@
 
 /datum/sprite_accessory/hair/mohawk
 	name = "Mohawk"
-	icon_state = "hair_mohawk"
+	icon_state = "hair_d"
 
 /datum/sprite_accessory/hair/reversemohawk
 	name = "Mohawk (Reverse)"


### PR DESCRIPTION
fixed two misnamed hairs

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
gives sonoida his gahdamn hair back. bald-ass.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: long-gloomy and mohawk's improper icon-paths
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
