### PR TITLE
Adds in the wand of gluttony

### DIFF
--- a/GainStation13/code/mechanics/wand.dm
+++ b/GainStation13/code/mechanics/wand.dm
@@ -1,0 +1,54 @@
+/obj/item/gun/magic/wand/food
+	name = "wand of gluttony"
+	desc = "summons delicious fattening foods"
+	max_charges = 15
+	ammo_type = /obj/item/ammo_casing/magic/food
+
+/obj/item/gun/magic/wand/food/overpowered //This is a more overpowered version of the item
+	name = "strong wand of gluttony"
+	max_charges = 100
+	ammo_type = /obj/item/ammo_casing/magic/food/strong
+
+/obj/item/ammo_casing/magic/food
+	projectile_type = /obj/item/projectile/magic/food
+
+/obj/item/ammo_casing/magic/food/strong
+	projectile_type = /obj/item/projectile/magic/food/strong
+
+/obj/item/projectile/magic/food
+	name = "bolt of food"
+	pass_flags = PASSGLASS|PASSDOOR|PASSGRILLE
+	///What foods are able to be spawned by the wand?
+	var/list/spawnable_foods = list(
+		/obj/item/reagent_containers/food/snacks/burger/bigbite,
+		/obj/item/reagent_containers/food/snacks/donut/plain,
+		/obj/item/reagent_containers/food/snacks/donut/glaze,
+		/obj/item/reagent_containers/food/snacks/store/cake/cheese,
+		/obj/item/reagent_containers/food/snacks/store/cake/birthday,
+		/obj/item/reagent_containers/food/snacks/store/cake/chocolate,
+		/obj/item/reagent_containers/food/snacks/hotdog,
+		/obj/item/reagent_containers/food/snacks/pizza/margherita,
+		/obj/item/reagent_containers/food/snacks/pizza/meat,
+	)
+	
+	///How much Lipoifier should be added to the spawned in food? Keep this at 10 maximum.
+	var/lipoifier_to_add = 5
+
+/obj/item/projectile/magic/food/on_hit(atom/target, blocked)
+	. = ..()
+
+	var/turf/floor = get_turf(target)
+	if(!floor || iswallturf(floor))
+		return FALSE
+
+	var/food_to_spawn = pick(spawnable_foods)	
+	var/obj/item/reagent_containers/food/snacks/spawned_food = new food_to_spawn(floor)
+	if(!spawned_food)
+		return FALSE
+
+	spawned_food.reagents.add_reagent(/datum/reagent/consumable/lipoifier, lipoifier_to_add) 
+	return TRUE
+	
+/obj/item/projectile/magic/food/strong
+	name = "strong bolt of food"
+	lipoifier_to_add = 10

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3075,6 +3075,7 @@
 #include "GainStation13\code\machinery\feeding_tube.dm"
 #include "GainStation13\code\mechanics\fatness.dm"
 #include "GainStation13\code\mechanics\spells.dm"
+#include "GainStation13\code\mechanics\wand.dm"
 #include "GainStation13\code\modules\client\preferences\preferences.dm"
 #include "GainStation13\code\modules\mob\living\emote.dm"
 #include "GainStation13\code\modules\reagents\chemistry\reagents\consumable_reagents.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in the wand of gluttony, a wand that spawns food with lipoifier under anything that it hits.
This is currently admin-spawn in only right now, as I'm not sure where I'd like to put this.

The wands use the default wand sprite, so if someone else would be interested in coding in a new sprite for them, I'd be happy to add it in.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More stuff to use for events is always good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds in the wand of gluttony, a wand that spawns lipoifier infused food under anything it hits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
