### PR TITLE
Refactors the weight gain movement speed penalty

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -170,7 +170,7 @@
 //Math stuff for fatness movement speed
 #define FATNESS_DIVISOR 860 
 #define FATNESS_MAX_MOVE_PENALTY 4
-#define FATNESS_WEAKLEGS_MODIFIER 10
+#define FATNESS_WEAKLEGS_MODIFIER 20
 
 //Nutrition levels for humans
 #define NUTRITION_LEVEL_FULL 550

--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -167,6 +167,11 @@
 #define FATNESS_LEVEL_FATTER 250
 #define FATNESS_LEVEL_FAT 170
 
+//Math stuff for fatness movement speed
+#define FATNESS_DIVISOR 860 
+#define FATNESS_MAX_MOVE_PENALTY 4
+#define FATNESS_WEAKLEGS_MODIFIER 10
+
 //Nutrition levels for humans
 #define NUTRITION_LEVEL_FULL 550
 #define NUTRITION_LEVEL_WELL_FED 450

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1818,26 +1818,20 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
 	return .
 */
-		if(HAS_TRAIT(H, TRAIT_FAT))
-			. += (1 - flight)
-		if(HAS_TRAIT(H, TRAIT_FATTER))
-			. += (1.1 - flight)
-		if(HAS_TRAIT(H, TRAIT_VERYFAT))
-			. += (1.25 - flight)
-		if(HAS_TRAIT(H, TRAIT_OBESE))//GS13 fat levels move speed decrease
-			. += (1.5 - flight)
-		if(HAS_TRAIT(H, TRAIT_MORBIDLYOBESE))
-			. += (2 - flight)
-		if(HAS_TRAIT(H, TRAIT_EXTREMELYOBESE))
-			. += (2.5 - flight)
-		if(HAS_TRAIT(H, TRAIT_BARELYMOBILE))
-			. += 2.7
-		if(HAS_TRAIT(H, TRAIT_IMMOBILE))
-			. += 3 // No wings are going to lift that much off the ground
-		if(HAS_TRAIT(H, TRAIT_BLOB))
-			. += 4
+		if(H.fatness)
+			var/fatness_delay = (H.fatness / FATNESS_DIVISOR)
+			if(H.fatness < FATNESS_LEVEL_BARELYMOBILE)
+				fatness_delay = fatness_delay - flight
+			
+			fatness_delay = min(fatness_delay, FATNESS_MAX_MOVE_PENALTY)
+			if(HAS_TRAIT(H, TRAIT_WEAKLEGS) && (H.fatness > FATNESS_LEVEL_BLOB))
+				fatness_delay += ((H.fatness - FATNESS_LEVEL_BLOB) * FATNESS_WEAKLEGS_MODIFIER) / FATNESS_DIVISOR	
+	
+			. += fatness_delay 
+
 		if(H.bodytemperature < BODYTEMP_COLD_DAMAGE_LIMIT && !HAS_TRAIT(H, TRAIT_RESISTCOLD))
 			. += (BODYTEMP_COLD_DAMAGE_LIMIT - H.bodytemperature) / COLD_SLOWDOWN_FACTOR
+
 	return .
 //////////////////
 // ATTACK PROCS //

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -85,8 +85,6 @@
 	if(!mob.Process_Spacemove(direct))
 		return FALSE
 		
-	if(HAS_TRAIT(mob,TRAIT_BLOB) && HAS_TRAIT(mob,TRAIT_WEAKLEGS)) // GS13 are we too fat to move? 
-		return FALSE	
 	//We are now going to move
 	var/add_delay = mob.movement_delay()
 	mob.set_glide_size(DELAY_TO_GLIDE_SIZE(add_delay * (((direct & 3) && (direct & 12)) ? 2 : 1))) // set it now in case of pulled objects


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Refactors the movement speed penalty added by weight gain. Weight added now gradually effects the movement speed instead of in stages like before. 

The weak legs trait has been changed so that instead of making the user completely immobile, it gives them an incredibly heavy movement speed penalty after getting past the blob stage.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This makes the code less pain to work with, and hopefully makes the weight gain system more enjoyable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
refactor: refactors the movement speed penalities for weight gain
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
