### PR TITLE
Weight Gain virus now uses stage speed instead of transmission

### DIFF
--- a/code/datums/diseases/advance/symptoms/weight.dm
+++ b/code/datums/diseases/advance/symptoms/weight.dm
@@ -66,8 +66,8 @@ Bonus
 	symptom_delay_min = 15
 	symptom_delay_max = 45
 	threshold_desc = list(
-		"Transmission 7" = "Increases the rate of cell replication.",
-		"Transmission 12" = "Increases the rate of cell replication further"
+		"Stage Speed 7" = "Increases the rate of cell replication.",
+		"Stage Speed 12" = "Increases the rate of cell replication further"
 	)
 
 
@@ -83,9 +83,9 @@ Bonus
 				to_chat(M, "<span class='warning'>[pick("You feel oddly full...", "You feel more plush...", "You feel more huggable...", "You hear an odd gurgle from your stomach")]</span>")
 		else
 			to_chat(M, "<span class='warning'><i>[pick("You feel your body churn...", "You feel heavier...", "You hear an ominous gurgle from your belly...", "You feel bulkier...")]</i></span>")
-			if(A.properties["transmittable"] >= 12) //get chunkier quicker
+			if(A.properties["stage_rate"] >= 12) //get chunkier quicker
 				M.adjust_fatness(70, FATTENING_TYPE_VIRUS)	
-			else if(A.properties["transmittable"] >= 7)
+			else if(A.properties["stage_rate"] >= 7)
 				M.adjust_fatness(40, FATTENING_TYPE_VIRUS)	
 			else
 				M.adjust_fatness(15, FATTENING_TYPE_VIRUS)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Instead of using transmission for thresholds, the weight gain virus now uses stage speed.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I don't like needing to infect the entire station so that I can make a fattening virus that works well.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: The weight gain virus symptom now uses stage speed instead of transmission.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
