### PR TITLE
Calorite statue fixes.

### DIFF
--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -349,17 +349,17 @@
 		to_chat(M, "<span class='warning'>Nothing happens.</span>")
 		return 
 
-	if(M.fatness < FATNESS_LEVEL_FAT)
+	if(M.fatness < FATNESS_LEVEL_FATTER)
 		to_chat(M, "<span class='warning'>The moment your hand meets the statue, you feel a little warmer...</span>")
-	else if(M.fatness < FATNESS_LEVEL_VERYFAT)
+	else if(M.fatness < FATNESS_LEVEL_OBESE)
 		to_chat(M, "<span class='warning'>Upon each poke of the statue, you feel yourself get a little heavier.</span>")
-	else if(M.fatness < FATNESS_LEVEL_MORBIDLY_OBESE)
+	else if(M.fatness < FATNESS_LEVEL_EXTREMELY_OBESE)
 		to_chat(M, "<span class='warning'>With each touch you keep getting fatter... But the fatter you grow, the more enticed you feel to poke the statue.</span>")
 	else if(M.fatness < FATNESS_LEVEL_BARELYMOBILE)
 		to_chat(M, "<span class='warning'>The world around you blurs as you focus on prodding the statue, your waistline widening further...</span>")
 	else if(M.fatness < FATNESS_LEVEL_IMMOBILE)
 		to_chat(M, "<span class='warning'>A whispering voice gently compliments your massive body, your own mind begging to touch the statue more.</span>")
-	else if(M.fatness < FATNESS_LEVEL_BLOB)
+	else
 		to_chat(M, "<span class='warning'>You can barely reach the statue past your floor-covering stomach! And yet, it still calls to you...</span>")
 
 /obj/structure/statue/calorite/fatty/Bumped(atom/movable/AM)
@@ -384,5 +384,3 @@
 
 /obj/structure/statue/calorite/fatty/attack_paw(mob/living/carbon/M)
 	statue_fatten(M)
-
-

--- a/code/game/objects/structures/statues.dm
+++ b/code/game/objects/structures/statues.dm
@@ -333,7 +333,7 @@
 	var/active = null
 	var/last_event = 0
 
-/obj/structure/statue/calorite/fatty/proc/beacon()
+/obj/structure/statue/calorite/fatty/proc/beckon()
 	if(!active)
 		if(world.time > last_event+15)
 			active = 1
@@ -344,70 +344,45 @@
 			return
 	return
 
+/obj/structure/statue/calorite/fatty/proc/statue_fatten(mob/living/carbon/M)
+	if(!M.adjust_fatness(20, FATTENING_TYPE_ITEM))
+		to_chat(M, "<span class='warning'>Nothing happens.</span>")
+		return 
+
+	if(M.fatness < FATNESS_LEVEL_FAT)
+		to_chat(M, "<span class='warning'>The moment your hand meets the statue, you feel a little warmer...</span>")
+	else if(M.fatness < FATNESS_LEVEL_VERYFAT)
+		to_chat(M, "<span class='warning'>Upon each poke of the statue, you feel yourself get a little heavier.</span>")
+	else if(M.fatness < FATNESS_LEVEL_MORBIDLY_OBESE)
+		to_chat(M, "<span class='warning'>With each touch you keep getting fatter... But the fatter you grow, the more enticed you feel to poke the statue.</span>")
+	else if(M.fatness < FATNESS_LEVEL_BARELYMOBILE)
+		to_chat(M, "<span class='warning'>The world around you blurs as you focus on prodding the statue, your waistline widening further...</span>")
+	else if(M.fatness < FATNESS_LEVEL_IMMOBILE)
+		to_chat(M, "<span class='warning'>A whispering voice gently compliments your massive body, your own mind begging to touch the statue more.</span>")
+	else if(M.fatness < FATNESS_LEVEL_BLOB)
+		to_chat(M, "<span class='warning'>You can barely reach the statue past your floor-covering stomach! And yet, it still calls to you...</span>")
+
 /obj/structure/statue/calorite/fatty/Bumped(atom/movable/AM)
-	beacon()
+	beckon()
 	..()
 
 /obj/structure/statue/calorite/fatty/Crossed(var/mob/AM)
 	.=..()
 	if(!.)
 		if(istype(AM))
-			beacon()
+			beckon()
 
 /obj/structure/statue/calorite/fatty/Moved(atom/movable/AM)
-	beacon()
+	beckon()
 	..()
 
 /obj/structure/statue/calorite/fatty/attackby(obj/item/W, mob/living/carbon/M, params)
-	if(!M.adjust_fatness(20, FATTENING_TYPE_ITEM))
-		to_chat(M, "<span class='warning'>Nothing happens.</span>")
-		return
-
-	if(M.fatness < 200)
-		to_chat(M, "<span class='warning'>The moment your hand meets the statue, you feel a little warmer...</span>")
-	if(HAS_TRAIT(M, TRAIT_FAT))
-		to_chat(M, "<span class='warning'>Upon each poke of the statue, you feel yourself get a little heavier.</span>")
-	if(HAS_TRAIT(M, TRAIT_OBESE))
-		to_chat(M, "<span class='warning'>With each touch you keep getting fatter... But the fatter you grow, the more enticed you feel to poke the statue.</span>")
-	if(HAS_TRAIT(M, TRAIT_MORBIDLYOBESE))
-		to_chat(M, "<span class='warning'>The world around you blurs as you focus on prodding the statue, your waistline widening further...</span>")
-	if(HAS_TRAIT(M, TRAIT_IMMOBILE))
-		to_chat(M, "<span class='warning'>A whispering voice gently compliments your massive body, your own mind begging to touch the statue more.</span>")
-	if(HAS_TRAIT(M, TRAIT_BLOB))
-		to_chat(M, "<span class='warning'>You can barely reach the statue past your floor-covering stomach! And yet, it still calls to you...</span>")
+	statue_fatten(M)
 
 /obj/structure/statue/calorite/fatty/attack_hand(mob/living/carbon/M)
-	if(!M.adjust_fatness(20, FATTENING_TYPE_ITEM))
-		to_chat(M, "<span class='warning'>Nothing happens.</span>")
-		return
-
-	if(M.fatness < 200)
-		to_chat(M, "<span class='warning'>The moment your hand meets the statue, you feel a little warmer...</span>")
-	if(HAS_TRAIT(M, TRAIT_FAT))
-		to_chat(M, "<span class='warning'>Upon each poke of the statue, you feel yourself get a little heavier.</span>")
-	if(HAS_TRAIT(M, TRAIT_OBESE))
-		to_chat(M, "<span class='warning'>With each touch you keep getting fatter... But the fatter you grow, the more enticed you feel to poke the statue.</span>")
-	if(HAS_TRAIT(M, TRAIT_MORBIDLYOBESE))
-		to_chat(M, "<span class='warning'>The world around you blurs as you focus on prodding the statue, your waistline widening further...</span>")
-	if(HAS_TRAIT(M, TRAIT_IMMOBILE))
-		to_chat(M, "<span class='warning'>A whispering voice gently compliments your massive body, your own mind begging to touch the statue more.</span>")
-	if(HAS_TRAIT(M, TRAIT_BLOB))
-		to_chat(M, "<span class='warning'>You can barely reach the statue past your floor-covering stomach! And yet, it still calls to you...</span>")
+	statue_fatten(M)
 
 /obj/structure/statue/calorite/fatty/attack_paw(mob/living/carbon/M)
-	if(!M.adjust_fatness(20, FATTENING_TYPE_ITEM))
-		to_chat(M, "<span class='warning'>Nothing happens.</span>")
-		return
+	statue_fatten(M)
 
-	if(M.fatness < 200)
-		to_chat(M, "<span class='warning'>The moment your hand meets the statue, you feel a little warmer...</span>")
-	if(HAS_TRAIT(M, TRAIT_FAT))
-		to_chat(M, "<span class='warning'>Upon each poke of the statue, you feel yourself get a little heavier.</span>")
-	if(HAS_TRAIT(M, TRAIT_OBESE))
-		to_chat(M, "<span class='warning'>With each touch you keep getting fatter... But the fatter you grow, the more enticed you feel to poke the statue.</span>")
-	if(HAS_TRAIT(M, TRAIT_MORBIDLYOBESE))
-		to_chat(M, "<span class='warning'>The world around you blurs as you focus on prodding the statue, your waistline widening further...</span>")
-	if(HAS_TRAIT(M, TRAIT_IMMOBILE))
-		to_chat(M, "<span class='warning'>A whispering voice gently compliments your massive body, your own mind begging to touch the statue more.</span>")
-	if(HAS_TRAIT(M, TRAIT_BLOB))
-		to_chat(M, "<span class='warning'>You can barely reach the statue past your floor-covering stomach! And yet, it still calls to you...</span>")
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Initially made to make the statue's messages work with the new fatness (Without writing more messages, but still.)
While there, I made a new unified proc to remove some duplicate code and changed beacon to beckon, as that seemed to match the proc's function better.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Helps people with shitty internet know that they are not lagging and that they did, in fact, click the statue. Also will be easier to modify in the future if someone really wants to write the four or so missing descriptions. Beckon was a bit of a nitpick though. Still, I think it helps clarity.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Calorite statue now has a message at any weight level.
refactor: Refactored the message choice.
refactor: The beacon proc is now beckon.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
