### PR TITLE
Fix duplicate crafting recipes

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -86,17 +86,13 @@
 		var/datum/emote/E = new path()
 		E.emote_list[E.key] = E
 
+	//Crafting Recipes
 	init_subtypes(/datum/crafting_recipe, GLOB.crafting_recipes)
 
-
-
-	// Hair Gradients - Initialise all /datum/sprite_accessory/hair_gradient into an list indexed by gradient-style name
+	//Hair Gradients - Initialise all /datum/sprite_accessory/hair_gradient into a list indexed by gradient-style name
 	for(var/path in subtypesof(/datum/sprite_accessory/hair_gradient))
 		var/datum/sprite_accessory/hair_gradient/H = new path()
 		GLOB.hair_gradients_list[H.name] = H
-
-	init_subtypes(/datum/crafting_recipe, GLOB.crafting_recipes)
-
 
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.


### PR DESCRIPTION
Remove second call to init_subtypes added with hair gradient update SHA: 8e402721dd0300f02483186b53126d25b4823ac7

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request removes a second call to init_subtypes that duplicates the list of crafting recipes. It also adds a comment to the first init_subtypes call and slightly adjusts the comment for the hair gradients list.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This pull request fixes a bug that was introduced in the hair gradient update.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: psq95
fix: duplicate crafting recipes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
