### PR TITLE
Fixes to weak legs

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -173,7 +173,7 @@
 //Math stuff for fatness movement speed
 #define FATNESS_DIVISOR 860 
 #define FATNESS_MAX_MOVE_PENALTY 4
-#define FATNESS_WEAKLEGS_MODIFIER 20
+#define FATNESS_WEAKLEGS_MODIFIER 35
 #define FATNESS_STRONGLEGS_MODIFIER 0.5
 
 //Nutrition levels for humans

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -517,3 +517,11 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 /datum/quirk/flimsy/remove() //how do admins even remove traits?
 	if(quirk_holder)
 		quirk_holder.maxHealth += healthchange
+
+/datum/quirk/weak_legs
+	name = "Weak Legs"
+	desc = "Your legs can't handle the heaviest of charges. Being too fat will render you unable to move at all."
+	mob_trait = TRAIT_WEAKLEGS
+	value = -1
+	category = CATEGORY_SEXUAL
+	medical_record_text = "Patient's legs seem to lack strength"

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -153,14 +153,6 @@
 	category = CATEGORY_SEXUAL	//Any better place to put it? Doesn't really affect gameplay
 	medical_record_text = "Patient cares little with or dislikes being touched."
 
-/datum/quirk/weak_legs
-	name = "Weak Legs"
-	desc = "Your legs can't handle the heaviest of charges. Being too fat will render you unable to move at all."
-	mob_trait = TRAIT_WEAKLEGS
-	value = 0
-	category = CATEGORY_SEXUAL
-	medical_record_text = "Patient's legs seem to lack strength"
-
 /datum/quirk/SpawnWithWheelchair
 	name = "Mobility Assistance"
 	desc = "After your last failed fitness test, you were advised to start using a hoverchair"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1867,8 +1867,12 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				fatness_delay = fatness_delay * FATNESS_STRONGLEGS_MODIFIER
 
 			fatness_delay = min(fatness_delay, FATNESS_MAX_MOVE_PENALTY)
-			if(HAS_TRAIT(H, TRAIT_WEAKLEGS) && (H.fatness > FATNESS_LEVEL_BLOB))
-				fatness_delay += ((H.fatness - FATNESS_LEVEL_BLOB) * FATNESS_WEAKLEGS_MODIFIER) / FATNESS_DIVISOR	
+			if(HAS_TRAIT(H, TRAIT_WEAKLEGS))
+				if(H.fatness <= FATNESS_LEVEL_IMMOBILE)
+					fatness_delay += fatness_delay * FATNESS_WEAKLEGS_MODIFIER / 100
+				if(H.fatness > FATNESS_LEVEL_IMMOBILE)
+					fatness_delay += (H.fatness / FATNESS_LEVEL_IMMOBILE) * FATNESS_WEAKLEGS_MODIFIER
+					fatness_delay = min(fatness_delay, 60)
 	
 			. += fatness_delay 
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Changed weak legs to increase the slowdown from fat by 35% at all levels and practically immobile when immobile and heavier. As a result of it always being active it now has a -1 cost.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Previous weak legs was broken and didn't do what it was supposed to do it now works as intended. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Fed09022
tweak: the effects of weak legs slowdown
fix: weak legs not making you immobile at very heavy weights
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
