### PR TITLE
Adjust sprite ranges in char setup

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -2428,14 +2428,14 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							to_chat(user,"<span class='danger'>Invalid color. Your color is not bright enough.</span>")
 
 				if("belly_size") //GS13 Edit here if we add more belly sprites
-					var/new_bellysize = input(user, "Belly size :\n(1-12) Odd = Rounded, Even = Fat", "Character Preference") as num|null
+					var/new_bellysize = input(user, "Belly size :\n(1-10)", "Character Preference") as num|null
 					if(new_bellysize)
-						features["belly_size"] = clamp(new_bellysize, 1, 12)
+						features["belly_size"] = clamp(new_bellysize, 1, 10)
 
 				if("butt_size")
-					var/new_buttsize = input(user, "Butt size :\n(0-5)", "Character Preference") as num|null
+					var/new_buttsize = input(user, "Butt size :\n(1-10)", "Character Preference") as num|null
 					if(new_buttsize)
-						features["butt_size"] = clamp(new_buttsize, 0, 5)
+						features["butt_size"] = clamp(new_buttsize, 1, 10)
 
 				if("vag_shape")
 					var/new_shape

--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -252,7 +252,7 @@
 	if(!getorganslot("anus"))
 		var/obj/item/organ/genital/anus/A = new
 		if(dna.features["butt_size"])
-			A.size = dna.features["butt_size"]
+			A.size = dna.features["butt_size"]-1
 		A.Insert(src)
 		if(A)
 			if(dna.species.use_skintones && dna.features["genitals_use_skintone"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Belly: 1-12 -> 1-10
Butt: 0-5 -> 1-10

Butt actually has an extra sprite (11) but I think 1-10 for both is better for consistency.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bring character setup in line with supported sprites.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: psq95
fix: butt sprite range in char setup
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
