### PR TITLE
Fix Silicon Examine Text

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -570,11 +570,20 @@
 #define COMSIG_HUMAN_MELEE_UNARMED_ATTACKBY "human_melee_unarmed_attackby"
 ///Hit by successful disarm attack (mob/living/carbon/human/attacker,zone_targeted)
 #define COMSIG_HUMAN_DISARM_HIT	"human_disarm_hit"
-#define COMSIG_HUMAN_PREFS_COPIED_TO "human_prefs_copied_to"					//from datum/preferences/copy_to(): (datum/preferences, icon_updates, roundstart_checks)
-#define COMSIG_HUMAN_HARDSET_DNA "human_hardset_dna"							//from mob/living/carbon/human/hardset_dna(): (ui, se, newreal_name, newblood_type, datum/species, newfeatures)
-#define COMSIG_HUMAN_ON_RANDOMIZE "humman_on_randomize"							//from base of proc/randomize_human()
+///from datum/preferences/copy_to(): (datum/preferences, icon_updates, roundstart_checks)
+#define COMSIG_HUMAN_PREFS_COPIED_TO "human_prefs_copied_to"
+///from mob/living/carbon/human/hardset_dna(): (ui, se, newreal_name, newblood_type, datum/species, newfeatures)
+#define COMSIG_HUMAN_HARDSET_DNA "human_hardset_dna"
+///from base of proc/randomize_human()
+#define COMSIG_HUMAN_ON_RANDOMIZE "humman_on_randomize"
 ///Whenever EquipRanked is called, called after job is set
 #define COMSIG_JOB_RECEIVED "job_received"
+
+// GS13: Silicon Examine Text
+// /mob/living/silicon signals
+
+//from datum/preferences/copy_to(): (datum/preferences, icon_updates, roundstart_checks)
+#define COMSIG_SILICON_PREFS_COPIED_TO "silicon_prefs_copied_to"
 
 // /datum/species signals
 
@@ -731,7 +740,6 @@
 //
 ///from datum/action/cyborg_small_sprite and sends when a cyborg changes modules
 #define COMSIG_CYBORG_MODULE_CHANGE "cyborg_module_change"
-
 
 /* Attack signals. They should share the returned flags, to standardize the attack chain. */
 /// tool_act -> pre_attack -> target.attackby (item.attack) -> afterattack

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -40,9 +40,6 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		LAZYOR(GLOB.mobs_with_editable_flavor_text[M], src)
 		M.verbs |= /mob/proc/manage_flavor_tests
 
-	if(save_key && ishuman(target))
-		RegisterSignal(target, COMSIG_HUMAN_PREFS_COPIED_TO, .proc/update_prefs_flavor_text)
-
 /datum/element/flavor_text/Detach(atom/A)
 	. = ..()
 	UnregisterSignal(A, list(COMSIG_PARENT_EXAMINE, COMSIG_HUMAN_PREFS_COPIED_TO))
@@ -150,9 +147,9 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		return TRUE
 	return FALSE
 
-/datum/element/flavor_text/proc/update_prefs_flavor_text(mob/living/carbon/human/H, datum/preferences/P, icon_updates = TRUE, roundstart_checks = TRUE)
+/datum/element/flavor_text/proc/update_prefs_flavor_text(mob/M, datum/preferences/P, icon_updates = TRUE, roundstart_checks = TRUE)
 	if(P.features.Find(save_key))
-		texts_by_atom[H] = P.features[save_key]
+		texts_by_atom[M] = P.features[save_key]
 
 //subtypes with additional hooks for DNA and preferences.
 /datum/element/flavor_text/carbon
@@ -169,6 +166,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	RegisterSignal(target, COMSIG_CARBON_IDENTITY_TRANSFERRED_TO, .proc/update_dna_flavor_text)
 	RegisterSignal(target, COMSIG_MOB_ANTAG_ON_GAIN, .proc/on_antag_gain)
 	if(ishuman(target))
+		RegisterSignal(target, COMSIG_HUMAN_PREFS_COPIED_TO, .proc/update_prefs_flavor_text)
 		RegisterSignal(target, COMSIG_HUMAN_HARDSET_DNA, .proc/update_dna_flavor_text)
 		RegisterSignal(target, COMSIG_HUMAN_ON_RANDOMIZE, .proc/unset_flavor)
 
@@ -193,3 +191,18 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		texts_by_atom[user] = ""
 		if(user.dna)
 			user.dna.features[save_key] = ""
+
+// GS13: Silicon Examine Text
+/datum/element/flavor_text/silicon
+
+/datum/element/flavor_text/silicon/Attach(datum/target, text = "", _name = "Flavor Text", _addendum, _max_len = MAX_FLAVOR_LEN, _always_show = FALSE, _edit = TRUE, _save_key = "flavor_text", _examine_no_preview = FALSE)
+	if(!issilicon(target))
+		return ELEMENT_INCOMPATIBLE
+	. = ..()
+	if(. == ELEMENT_INCOMPATIBLE)
+		return
+	RegisterSignal(target, COMSIG_SILICON_PREFS_COPIED_TO, .proc/update_prefs_flavor_text)
+
+/datum/element/flavor_text/silicon/Detach(mob/living/carbon/C)
+	. = ..()
+	UnregisterSignal(C, list(COMSIG_SILICON_PREFS_COPIED_TO))

--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -68,7 +68,7 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 	if(examine_no_preview)
 		examine_list += "<span class='notice'><a href='?src=[REF(src)];show_flavor=[REF(target)]'>\[[flavor_name]\]</a></span>"
 		return
-	var/msg = replacetext(text, "\n", " ")
+	var/msg = replacetext(text, "\n", "<br>") // preserve newlines
 	if(length_char(msg) <= 40)
 		examine_list += "<span class='notice'>[msg]</span>"
 	else
@@ -76,13 +76,21 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 
 	//Examine Tab stuff - Hyperstation
 	examineTabOutput = "<center>"
+
 	if(ishuman(target)) //user just returned, y'know, the user's own species. dumb.
 		var/mob/living/carbon/human/L = target
 		if(L.gender)
 			examineTabOutput += "[icon2html('hyperstation/icons/chat/gender.dmi', world, L.gender)]"
-
 		examineTabOutput += "[L.name] "
 		examineTabOutput += "([L.dna.custom_species ? L.dna.custom_species : L.dna.species.name])"
+
+	// GS13: Silicon Examine Text
+	if(iscyborg(target))
+		var/mob/living/silicon/robot/R = target
+		if (R.gender)
+			examineTabOutput += "[icon2html('hyperstation/icons/chat/gender.dmi', world, R.gender)]"
+		examineTabOutput += "[R.name] "
+		examineTabOutput += "([R.get_standard_name()])"
 
 /*		if(L.client?.prefs?.pins) //character has pins
 			var/P = ""
@@ -91,11 +99,13 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 */
 	examineTabOutput += "</center>"
 	examineTabOutput += "<br>[url_encode(msg)]"
+
 	if(ismob(target))
 		var/mob/M = target
 		if(M.ooc_text)
 			examineTabOutput += "<br><br><i><b>OOC</b>"
 			examineTabOutput += "<br>[url_encode(M.ooc_text)]"
+
 	user.client << output(examineTabOutput, "statbrowser:update_examine") //open the examine window
 	user.client << output(null, "statbrowser:create_mobexamine") //open the examine window
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3003,6 +3003,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 // GS13: Silicon Examine Text
 /datum/preferences/proc/copy_to_robot(mob/living/silicon/robot/cyborg, icon_updates = 1, roundstart_checks = TRUE)
 	SEND_SIGNAL(cyborg, COMSIG_SILICON_PREFS_COPIED_TO, src, icon_updates, roundstart_checks)
+	cyborg.ooc_text = features["ooc_text"]
 
 /datum/preferences/proc/get_default_name(name_id)
 	switch(name_id)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -3000,6 +3000,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	character.update_hair()
 	character.update_body_parts()
 
+// GS13: Silicon Examine Text
+/datum/preferences/proc/copy_to_robot(mob/living/silicon/robot/cyborg, icon_updates = 1, roundstart_checks = TRUE)
+	SEND_SIGNAL(cyborg, COMSIG_SILICON_PREFS_COPIED_TO, src, icon_updates, roundstart_checks)
 
 /datum/preferences/proc/get_default_name(name_id)
 	switch(name_id)

--- a/code/modules/jobs/job_types/silicon.dm
+++ b/code/modules/jobs/job_types/silicon.dm
@@ -88,3 +88,5 @@ Cyborg
 /datum/job/cyborg/after_spawn(mob/living/silicon/robot/R, mob/M)
 	R.updatename(M.client)
 	R.gender = NEUTER
+	// GS13: Silicon Examine Text
+	M.client?.prefs?.copy_to_robot(R)

--- a/code/modules/mob/living/silicon/examine.dm
+++ b/code/modules/mob/living/silicon/examine.dm
@@ -1,5 +1,9 @@
-/mob/living/silicon/examine(mob/user) //Displays a silicon's laws to ghosts
-	. = ..()
+/mob/living/silicon/examine(mob/user)
+	// GS13: Silicon Examine Text
+	// COMSIG_PARENT_EXAMINE is called in /mob/living/silicon/robot/examine instead of /atom/proc/examine
+	// to display flavour_text in the examine text span similar to /mob/living/carbon/human/examine
+
+	//Display a silicon's laws to ghosts
 	if(laws && isobserver(user))
 		. += "<b>[src] has the following laws:</b>"
 		for(var/law in laws.get_law_list(include_zeroth = TRUE))

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -48,5 +48,9 @@
 			. += "<span class='warning'>It doesn't seem to be responding.</span>"
 		if(DEAD)
 			. += "<span class='deadsay'>It looks like its system is corrupted and requires a reset.</span>"
+
+	// GS13: Silicon Examine Text
+	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)
+
 	. += "*---------*</span>"
 	. += ..()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -57,7 +57,8 @@
 
 /mob/living/silicon/ComponentInitialize()
 	. = ..()
-	AddElement(/datum/element/flavor_text, "", "Silicon Flavor Text", "", MAX_FLAVOR_LEN, FALSE, TRUE, "silicon_flavor_text")
+	// GS13: Silicon Examine Text
+	AddElement(/datum/element/flavor_text/silicon, "", "Silicon Flavor Text", "", MAX_FLAVOR_LEN, FALSE, TRUE, "silicon_flavor_text")
 	AddElement(/datum/element/flavor_text, "", "Temporary Flavor Text", "This should be used only for things pertaining to the current round!")
 
 /mob/living/silicon/med_hud_set_health()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -372,9 +372,6 @@
 
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
 
-	// GS13: Silicon Examine Text
-	SEND_SIGNAL(R, COMSIG_SILICON_PREFS_COPIED_TO, src)
-
 	R.gender = gender
 	R.invisibility = 0
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -372,6 +372,9 @@
 
 	var/mob/living/silicon/robot/R = new /mob/living/silicon/robot(loc)
 
+	// GS13: Silicon Examine Text
+	SEND_SIGNAL(R, COMSIG_SILICON_PREFS_COPIED_TO, src)
+
 	R.gender = gender
 	R.invisibility = 0
 

--- a/modular_citadel/code/modules/client/preferences.dm
+++ b/modular_citadel/code/modules/client/preferences.dm
@@ -57,7 +57,7 @@
 			if(L[slot_to_string(slot)] < DEFAULT_SLOT_AMT)
 				return TRUE
 
-datum/preferences/copy_to(mob/living/carbon/human/character, icon_updates = 1)
+/datum/preferences/copy_to(mob/living/carbon/human/character, icon_updates = 1)
 	..()
 	character.give_genitals(TRUE)
 	character.ooc_text = features["ooc_text"] //Let's update their flavor_text at least initially


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Propagate silicon examine text from client preferences to robot mob.
Only applies to Cyborg job role, not robotized "humans".
Also preserves newlines in all flavor text.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Features should work as intended.
Examine text is easier to read in lines than one long string.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: psq95
fix: silicon examine text
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
