### PR TITLE
Gluttony's blessing update

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -286,6 +286,24 @@
 	new_form = /mob/living/simple_animal/hostile/morph
 	infectable_biotypes = MOB_ORGANIC|MOB_INORGANIC|MOB_UNDEAD //magic!
 
+//To be the new transformation for the Gluttony's blessing
+/datum/disease/transformation/cakegolem
+	name = "Gluttony's Blessing"
+	cure_text = "nothing"
+	cures = list(/datum/reagent/medicine/adminordrazine)
+	agent = "Gluttony's Blessing"
+	desc = "A 'gift' from somewhere fattening."
+	stage_prob = 20
+	severity = DISEASE_SEVERITY_BIOHAZARD
+	visibility_flags = 0
+	stage1	= list("You start to taste cake in your mouth")
+	stage2	= list(",span class='danger'>Colored spots start to form all over your body.</span>")
+	stage3	= list("<span class='danger'>Your body begins to puff up.</span>", "<span class='danger'>Your pours start to shoot out a white substance.</span>") //ITS FROSTING NOT CUM SHUSH
+	stage4	= list("<span class='danger'>Your flesh starts to hollow out, while everything that made you, you dissapears.</span>")
+	stage5	= list("<span class='danger'>You have become a cakegolem, with the one though to feed everyone.</span>")
+	new_form = /mob/living/simple_animal/friendly/cakegolem
+	infectable_biotypes = MOB_ORGANIC|MOB_INORGANIC|MOB_UNDEAD //magic!
+
 /datum/disease/transformation/gondola
 	name = "Gondola Transformation"
 	cure_text = "Condensed Capsaicin, ingested or injected." //getting pepper sprayed doesn't help

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -850,7 +850,7 @@
 	taste_description = "decay"
 
 /datum/reagent/gluttonytoxin/reaction_mob(mob/living/L, method=TOUCH, reac_volume)
-	L.ForceContractDisease(new /datum/disease/transformation/morph(), FALSE, TRUE)
+	L.ForceContractDisease(new /datum/disease/transformation/cakegolem(), FALSE, TRUE)
 
 /datum/reagent/serotrotium
 	name = "Serotrotium"


### PR DESCRIPTION
## About The Pull Request

An update to the blessing found within the gluttony ruin, to make the gluttony blessing, do something that makes more sense

## Why It's Good For The Game

Makes the gluttony blessing an item that people will actually want to take, and reduces the posibility to self antag.

## Changelog
:cl:
tweak: changed the morph transformation with a cakegolem one
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
