### PR TITLE
Hair gradients fix and Beltbuster use fixed

### DIFF
--- a/GainStation13/code/modules/reagents/chemistry/reagents/fatty_drinks.dm
+++ b/GainStation13/code/modules/reagents/chemistry/reagents/fatty_drinks.dm
@@ -53,7 +53,7 @@
 	shot_glass_icon_state = "shotglassgold"
 	hydration = 4
 
-/datum/reagent/consumable/snakebite/on_mob_life(mob/living/carbon/M)
+/datum/reagent/consumable/ethanol/beltbuster_mead/on_mob_life(mob/living/carbon/M)
 	if(M && M?.client?.prefs.weight_gain_chems) // GS13
 		M.nutrition += 30 * REAGENTS_METABOLISM
 	else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -97,7 +97,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/wing_color = "fff"				//Wing color
 	// GS13: Hair gradients from Skyrat
 	var/grad_color = "FFFFFF"			//Hair gradient color
-	var/grad_style = "000"				//Hair gradient style
+	var/grad_style = "None"				//Hair gradient style
 
 	//HS13
 	var/body_size = 100					//Body Size in percent

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -12,7 +12,7 @@
 
 	// GS13: Hair gradients from Skyrat
 	var/grad_color = "FFFFFF"
-	var/grad_style = "000"
+	var/grad_style = "None"
 
 	//Facial hair colour and style
 	var/facial_hair_color = "000"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -468,8 +468,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 						hair_overlay.color = "#" + H.hair_color
 
 					// GS13: Hair gradients from Skyrat
-					grad_style = H.grad_style
-					grad_color = H.grad_color
+					var/grad_style = H.grad_style
+					var/grad_color = H.grad_color
 					if(grad_style)
 						var/datum/sprite_accessory/gradient = GLOB.hair_gradients_list[grad_style]
 						var/icon/temp = icon(gradient.icon, gradient.icon_state)


### PR DESCRIPTION
Hair gradients are now instanced as "None", the default no gradients value, rather than 000 which caused runtime newly instanced character to cause runtime errors. Fixed the path for the Beltbuster Mead drink's on_mob_life function