### PR TITLE
Correcting SQL Admin import script

### DIFF
--- a/SQL/admin_import_2018-02-03.py
+++ b/SQL/admin_import_2018-02-03.py
@@ -30,27 +30,27 @@ def parse_text_flags(text, previous):
         for flag in flags:
             sign = flag[:1]
             if flag[1:] in ("@", "prev"):
-                if sign is "+":
+                if sign == "+":
                     flags_int = previous[0]
-                elif sign is "-":
+                elif sign == "-":
                     exclude_flags_int = previous[1]
-                elif sign is "*":
+                elif sign == "*":
                     can_edit_flags_int = previous[2]
                 continue
             if flag[1:] in ("EVERYTHING", "HOST", "ALL"):
-                if sign is "+":
+                if sign == "+":
                     flags_int = 65535
-                elif sign is "-":
+                elif sign == "-":
                     exclude_flags_int = 65535
-                elif sign is "*":
+                elif sign == "*":
                     can_edit_flags_int = 65535
                 continue
             if flag[1:] in flag_values:
-                if sign is "+":
+                if sign == "+":
                     flags_int += flag_values[flag[1:]]
-                elif sign is "-":
+                elif sign == "-":
                     exclude_flags_int += flag_values[flag[1:]]
-                elif sign is "*":
+                elif sign == "*":
                     can_edit_flags_int += flag_values[flag[1:]]
     flags_int = max(min(65535, flags_int), 0)
     exclude_flags_int = max(min(65535, exclude_flags_int), 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This pull request is intended to fix a minor, yet pretty annoying issue. If someone were to use an SQL server for their own testing build, and they wanted to import from admins.txt, while it works, Python has this nasty habit of whinging about how it was written. Namely saying:

"SyntaxWarning: "is" with 'str' literal. Did you mean "=="?"

Guh.

## Why It's Good For The Game

If there are rookies who are running this locally for testing or whatever, the warnings might put them off. Fixing that does mean that more testing can take place.

## Changelog
:cl:
refactor: Changing "is" to "==" so that python stops moaning.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
