### PR TITLE
Genitals update fix (again)

### DIFF
--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -46,7 +46,8 @@
 	update_size()
 	update_appearance()
 	update_link()
-	owner.update_inv_w_uniform() //GS13: rebuild overlays on genitals appearance update, for modular clothes
+	if(owner)//GS13: rebuild overlays on genitals appearance update, for modular clothes
+		owner.update_inv_w_uniform() 
 
 //exposure and through-clothing code
 /mob/living/carbon


### PR DESCRIPTION
Added if to have the genital check if the owner exists when trying to update (skips the inventory update if not and updates the rest, so the body displays and updates correctly even if they are nude)