### PR TITLE
Halt autoclose when blocked too many times

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1204,9 +1204,16 @@
 			return
 	if(safe)
 		for(var/atom/movable/M in get_turf(src))
+			if (failCount > failThreshold) //something is continuously blocking the door
+				do_sparks(5, TRUE, src)
+				visible_message("<span class='warning'>[src]'s timing mechanism fails.</span>")
+				failCount = 0
+				return
 			if(M.density && M != src) //something is blocking the door
 				autoclose_in(60)
+				failCount++
 				return
+		failCount = 0
 
 	if(forced < 2)
 		if(obj_flags & EMAGGED)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -37,6 +37,10 @@
 	var/poddoor = FALSE
 	var/unres_sides = 0 //Unrestricted sides. A bitflag for which direction (if any) can open the door with no access
 
+	// GS13: Halt autoclose when blocked with static object, like a wooden barricade...
+	var/failCount = 0
+	var/failThreshold = 5
+
 /obj/machinery/door/examine(mob/user)
 	. = ..()
 	if(red_alert_access)
@@ -284,10 +288,16 @@
 		return
 	if(safe)
 		for(var/atom/movable/M in get_turf(src))
+			if (failCount > failThreshold) //something is continuously blocking the door
+				do_sparks(5, TRUE, src)
+				visible_message("<span class='warning'>[src]'s timing mechanism fails.</span>")
+				failCount = 0
+				return
 			if(M.density && M != src) //something is blocking the door
 				if(autoclose)
 					autoclose_in(60)
 				return
+		failCount = 0
 
 	operating = TRUE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change adds a failure count that increments each time a door attempts to close but something is blocking it. If it fails too many times, it simply stops trying. Doors can be closed manually once the blockage is removed.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wooden barricades in powered airlocks cause lag as the doors try to autoclose over and over.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: psq95
fix: Stop doors causing lag when blocked continuously
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
