### PR TITLE
Makes putting fatties in the gibber produce more meat

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -152,7 +152,8 @@
 	var/typeofmeat = /obj/item/reagent_containers/food/snacks/meat/slab/human
 	var/typeofskin
 
-	var/obj/item/reagent_containers/food/snacks/meat/slab/allmeat[meat_produced]
+	//var/obj/item/reagent_containers/food/snacks/meat/slab/allmeat[meat_produced] //Gainstation Edit: This has to be moved ahead to account for fatness adding
+	var/fatbonus //Gainstation Edit 2: Instead I'll define fatbonus here, since it needs to be in this scope
 	var/obj/item/stack/sheet/animalhide/skin
 	var/list/datum/disease/diseases = mob_occupant.get_static_viruses()
 
@@ -170,6 +171,15 @@
 			typeofskin = /obj/item/stack/sheet/animalhide/monkey
 		else if(isalien(C))
 			typeofskin = /obj/item/stack/sheet/animalhide/xeno
+
+		//Gainstation Edit Start: Fat people Produce more meat
+		var/efficiency
+		for(var/obj/item/stock_parts/matter_bin/B in component_parts)
+			efficiency += B.rating
+		fatbonus = C.fatness / max(1000 - (200 * efficiency), 200)
+
+	var/obj/item/reagent_containers/food/snacks/meat/slab/allmeat[meat_produced + fatbonus] //And now it gets defined..
+	//Gainstation Edit End
 
 	for (var/i=1 to meat_produced)
 		var/obj/item/reagent_containers/food/snacks/meat/slab/newmeat = new typeofmeat

--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -162,6 +162,8 @@
 		if(gibee.dna && gibee.dna.species)
 			typeofmeat = gibee.dna.species.meat
 			typeofskin = gibee.dna.species.skinned_type
+		
+		fatbonus = calc_fat_bonus(gibee.fatness) //Gainstation Edit: Fat people Produce more meat
 
 	else if(iscarbon(occupant))
 		var/mob/living/carbon/C = occupant
@@ -172,16 +174,13 @@
 		else if(isalien(C))
 			typeofskin = /obj/item/stack/sheet/animalhide/xeno
 
-		//Gainstation Edit Start: Fat people Produce more meat
-		var/efficiency
-		for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-			efficiency += B.rating
-		fatbonus = C.fatness / max(1000 - (200 * efficiency), 200)
+		
+		fatbonus = calc_fat_bonus(C.fatness) //Gainstation Edit: Fat people Produce more meat
 
-	var/obj/item/reagent_containers/food/snacks/meat/slab/allmeat[meat_produced + fatbonus] //And now it gets defined..
-	//Gainstation Edit End
+	var/obj/item/reagent_containers/food/snacks/meat/slab/allmeat[meat_produced + fatbonus] //Gainstation Edit: And now it gets defined...
+	
 
-	for (var/i=1 to meat_produced)
+	for (var/i=1 to (meat_produced + fatbonus)) //Gainstation Edit: Fat bonus
 		var/obj/item/reagent_containers/food/snacks/meat/slab/newmeat = new typeofmeat
 		newmeat.name = "[sourcename] [newmeat.name]"
 		if(istype(newmeat))
@@ -220,6 +219,15 @@
 	pixel_x = initial(pixel_x) //return to its spot after shaking
 	operating = FALSE
 	update_icon()
+
+//Gainstation Add: Fat bonus calculation
+/obj/machinery/gibber/proc/calc_fat_bonus(fatness)
+	var/efficiency
+	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
+		efficiency += B.rating
+	var/fatbonus = fatness / max(1000 - (200 * efficiency), 200)	// 800 fatness per bonus at T1, 600 at T2, 400 at T3 and finally capped at 200 fatness per bonus at T4. 
+	return fatbonus													// If a T5 bin is ever real, it'll stay capped at 200 fatness per slice instead of producing infinite meat. 
+//Gainstation Add End
 
 //auto-gibs anything that bumps into it
 /obj/machinery/gibber/autogibber


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes gibbers produce extra meat based on how fat the person getting turned into meat product is. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This enables recycling meat from fat people who have gone SSD forever as well as allowing morally questionable fattening of livestock (crew members) and/or humanified monkies. It is also very funny to watch a lot of meat shoot out of the gibber. 
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added extra meat comming out of the gibber when fat people get blended
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
